### PR TITLE
Handle missing llama_cpp dependency gracefully

### DIFF
--- a/aurora_ai
+++ b/aurora_ai
@@ -1,4 +1,10 @@
-from llama_cpp import Llama
+try:
+    from llama_cpp import Llama
+    LLAMA_AVAILABLE = True
+except ImportError:  # pragma: no cover - handled gracefully at runtime
+    Llama = None
+    LLAMA_AVAILABLE = False
+    print("❌ The `llama_cpp` package is not installed. Aurora will start without the local LLM.")
 from pathlib import Path
 import pygame
 import os
@@ -390,7 +396,14 @@ class AuroraCodeMindComplete:
     """
     def __init__(self, model_path, use_gpu=True, gpu_layers=10):
         print("Initializing AuroraCodeMindComplete...")
-        
+
+        if not LLAMA_AVAILABLE:
+            raise RuntimeError(
+                "llama_cpp is required to run Aurora's local language model. "
+                "Install the package and ensure native dependencies are available "
+                "before launching."
+            )
+
         # Detect GPU and set layers
         if use_gpu:
             print("🚀 GPU Mode Enabled!")


### PR DESCRIPTION
## Summary
- wrap the llama_cpp import in a guard so Aurora can surface a helpful message when the dependency is missing
- fail fast during Aurora initialisation if the local LLM backend is unavailable, guiding users to install llama_cpp

## Testing
- python -m compileall aurora_ai

------
https://chatgpt.com/codex/tasks/task_e_68d9a0299cd8832b965fa13749cec620